### PR TITLE
Artist Nougat 7.0: Removed ARTist as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 cmake-build-debug
-compiler/optimizing/artist.bak
 JIT_ART
 **/__pycache__/**
 make.sh
+compiler/optimizing/artist
+compiler/optimizing/artist.bak

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "compiler/optimizing/artist"]
-	path = compiler/optimizing/artist
-	url = https://github.com/Project-ARTist/ARTist.git	


### PR DESCRIPTION
- See new local_manifests/ at:

  https://artist.cispa.saarland/build-setup/