### PR TITLE
Artist Oreo 8.0: Removed ARTist as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ JIT_ART
 .idea
 cmake-build-debug
 make.sh
+compiler/optimizing/artist
+compiler/optimizing/artist.bak

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "compiler/optimizing/artist"]
-	path = compiler/optimizing/artist
-	url = https://github.com/Project-ARTist/ARTist.git
-	branch = master


### PR DESCRIPTION
- See new local_manifests/ at:

  https://artist.cispa.saarland/build-setup/